### PR TITLE
Update dataset_classification.py

### DIFF
--- a/gluoncv/torch/data/video_cls/dataset_classification.py
+++ b/gluoncv/torch/data/video_cls/dataset_classification.py
@@ -138,7 +138,7 @@ class VideoClsDataset(Dataset):
                     sample = self.dataset_samples[index]
                     buffer = self.loadvideo_decord(sample)
             buffer = self.data_transform(buffer)
-            return buffer, self.label_array[index], sample.split("/")[1].split(".")[0]
+            return buffer, self.label_array[index], sample.split("/")[-1].split(".")[0]
 
         elif self.mode == 'test':
             sample = self.test_dataset[index]


### PR DESCRIPTION
The indexing of 1 is incorrect. Given a path, it will think the file name is the first thing in the path. To be consistent with line 174 I simply replaced 1 with -1. But can also use os.path.basename(sample).split(".")[0]

I noticed this when I was using the feat_extract_pytorch.py in action_recognition, and tried to use my custom data paths in the txt file pointed to by VAL_ANNO_PATH in the configuration yaml files.